### PR TITLE
📝 Improve Documentation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,4 +79,4 @@ jobs:
       - name: Validate URLs
         run: |
           awesome_bot ./*.md src/*.rs src/**/*.cl --allow-dupe --request-delay 0.4 \
-          --white-list https://github.com/HrikB/createXcrunch.git https://get.nexte.st/latest/linux
+          --white-list https://github.com/HrikB/createXcrunch.git,https://get.nexte.st/latest/linux

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,4 +77,6 @@ jobs:
         run: gem install awesome_bot
 
       - name: Validate URLs
-        run: awesome_bot ./*.md src/*.rs src/**/*.cl --allow-dupe --request-delay 0.4
+        run: |
+          awesome_bot ./*.md src/*.rs src/**/*.cl --allow-dupe --request-delay 0.4 \
+          --white-list https://github.com/HrikB/createXcrunch.git https://get.nexte.st/latest/linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-/target
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# cargo build folder
+target

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # cargo build folder
 target
+
+# Default output file
+output.txt

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 1. **Clone the Repository**
 
 ```console
-git clone https://github.com/HrikB/createXcrunch
+git clone https://github.com/HrikB/createXcrunch.git
 cd createXcrunch
 ```
 
@@ -21,6 +21,48 @@ cargo build --release
 ```
 
 > Building on Windows currently fails (see [this](https://github.com/HrikB/createXcrunch/issues/1) issue). If you want to continue using Windows, we recommend using the Windows Subsystem for Linux (WSL) and installing Rust via `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`.
+
+## Example Setup on [Vast.ai](https://vast.ai)
+
+#### Update Linux
+
+```console
+sudo apt update && sudo apt upgrade
+```
+
+#### Install `build-essential` Packages
+
+> We need the GNU Compiler Collection (GCC) later.
+
+```console
+sudo apt install build-essential
+```
+
+#### Install CUDA Toolkit
+
+> `createXcrunch` uses [OpenCL](https://en.wikipedia.org/wiki/OpenCL) which is natively supported via the NVIDIA OpenCL extensions.
+
+```console
+sudo apt install nvidia-cuda-toolkit
+```
+
+#### Install Rust
+
+> Enter `1` to select the default option and press the `Enter` key to continue the installation. Restart the current shell after completing the installation.
+
+```console
+curl https://sh.rustup.rs -sSf | sh
+```
+
+#### Build `createxcrunch`
+
+```console
+git clone https://github.com/HrikB/createXcrunch.git
+cd createXcrunch
+cargo build --release
+```
+
+🎉 Congrats, now you're ready to crunch your salt(s)!
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 1. **Clone the Repository**
 
-```
+```console
 git clone https://github.com/HrikB/createXcrunch
 cd createXcrunch
 ```
 
 2. **Build the Project**
 
-```
+```console
 cargo build --release
 ```
 
@@ -48,6 +48,6 @@ PRs welcome!
 
 ## Acknowledgements
 
-- https://github.com/0age/create2crunch
-- https://github.com/Vectorized/function-selector-miner
-- https://github.com/pcaversaccio/createx
+- [`create2crunch`](https://github.com/0age/create2crunch)
+- [Function Selection Miner](https://github.com/Vectorized/function-selector-miner)
+- [`CreateX` – A Trustless, Universal Contract Deployer](https://github.com/pcaversaccio/createx)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ or
 ./target/release/createxcrunch create3 --help
 ```
 
+## Local Development
+
+We recommend using [`cargo-nextest`](https://nexte.st) as test runner for this repository. To install it on a Linux `x86_64` machine, invoke:
+
+```console
+curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+```
+
+Afterwards you can run the tests via:
+
+```console
+cargo nextest run
+```
+
 ## Contributions
 
 PRs welcome!

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt install nvidia-cuda-toolkit
 curl https://sh.rustup.rs -sSf | sh
 ```
 
-#### Build `createxcrunch`
+#### Build `createXcrunch`
 
 ```console
 git clone https://github.com/HrikB/createXcrunch.git


### PR DESCRIPTION
This PR adds documentation on how to properly set up your [Vast.ai](https://vast.ai) instance. I also put the `.env` files into the `.gitignore` to prevent accidentally pushing these files.