### PR TITLE
Populate the `PATTERN()` macro on all branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `createXcrunch`
 
 [![👮‍♂️ Sanity checks](https://github.com/HrikB/createXcrunch/actions/workflows/checks.yml/badge.svg)](https://github.com/HrikB/createXcrunch/actions/workflows/checks.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/license/mit/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/license/mit)
 
 `createXcrunch` is a [Rust](https://www.rust-lang.org)-based program designed to efficiently find _zero-leading_, _zero-containing_, or _pattern-matching_ addresses for the [CreateX](https://github.com/pcaversaccio/createx) contract factory. Uses [OpenCL](https://www.khronos.org/opencl/) in order to leverage a GPU's mining capabilities.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,10 +561,12 @@ pub fn mk_kernel_src(config: &Config) -> String {
 
     match &config.reward {
         RewardVariant::LeadingZeros { zeros_threshold } => {
+            writeln!(src, "#define PATTERN() 0").unwrap();
             writeln!(src, "#define LEADING_ZEROES {zeros_threshold}").unwrap();
             writeln!(src, "#define SUCCESS_CONDITION() hasLeading(digest)").unwrap();
         }
         RewardVariant::TotalZeros { zeros_threshold } => {
+            writeln!(src, "#define PATTERN() 0").unwrap();
             writeln!(src, "#define LEADING_ZEROES 0").unwrap();
             writeln!(src, "#define TOTAL_ZEROES {zeros_threshold}").unwrap();
             writeln!(src, "#define SUCCESS_CONDITION() hasTotal(digest)").unwrap();
@@ -573,6 +575,7 @@ pub fn mk_kernel_src(config: &Config) -> String {
             leading_zeros_threshold,
             total_zeros_threshold,
         } => {
+            writeln!(src, "#define PATTERN() 0").unwrap();
             writeln!(src, "#define LEADING_ZEROES {leading_zeros_threshold}").unwrap();
             writeln!(src, "#define TOTAL_ZEROES {total_zeros_threshold}").unwrap();
             writeln!(
@@ -585,6 +588,7 @@ pub fn mk_kernel_src(config: &Config) -> String {
             leading_zeros_threshold,
             total_zeros_threshold,
         } => {
+            writeln!(src, "#define PATTERN() 0").unwrap();
             writeln!(src, "#define LEADING_ZEROES {leading_zeros_threshold}").unwrap();
             writeln!(src, "#define TOTAL_ZEROES {total_zeros_threshold}").unwrap();
             writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,12 +493,14 @@ pub fn gpu(config: Config) -> ocl::Result<()> {
         let mut total = 0;
         let mut leading = 0;
         for (i, &b) in address.iter().enumerate() {
-            if b == 0 {
-                total += 1;
-            } else if leading == 0 {
-                // set leading on finding non-zero byte
-                leading = i;
+            #[rustfmt::skip]
+            if b != 0 { continue; };
+
+            if leading == i {
+                leading = i + 1;
             }
+
+            total += 1;
         }
 
         let output = format!("0x{} => 0x{}", hex::encode(salt), hex::encode(address),);


### PR DESCRIPTION
#6 showcases how not populating the `PATTERN()` macro inside the kernel can cause a build failure. This PR addresses that by populating the macro across all branches.

Also fixes incorrect leading zero count.

Closes #6 