### PR TITLE
Uppercase letters in matching fail to find address

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,13 @@ pub struct Cli {
 fn to_lowercase_boxed_str(s: &str) -> Result<Box<str>, &'static str> {
     let modified_string: String = s
         .chars()
-        .map(|c| if c != 'X' { c.to_lowercase().to_string() } else { c.to_string() })
+        .map(|c| {
+            if c != 'X' {
+                c.to_lowercase().to_string()
+            } else {
+                c.to_string()
+            }
+        })
         .collect();
     Ok(modified_string.into_boxed_str())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,14 @@ pub struct Cli {
     pub command: Commands,
 }
 
+fn to_lowercase_boxed_str(s: &str) -> Result<Box<str>, &'static str> {
+    let modified_string: String = s
+        .chars()
+        .map(|c| if c != 'X' { c.to_lowercase().to_string() } else { c.to_string() })
+        .collect();
+    Ok(modified_string.into_boxed_str())
+}
+
 #[derive(Args)]
 #[clap(group = ArgGroup::new("search-criteria").multiple(true).required(true))]
 #[clap(group = ArgGroup::new("zeros-threshold"))]
@@ -88,7 +96,8 @@ pub struct CliArgs {
         group = "search-criteria",
         long_help = "Matching pattern for the contract address. Cannot be used in combination with --leading.\n\nExample: --matching ba5edXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXba5ed.",
         help_heading = "Crunching options",
-        conflicts_with_all = &["zeros", "total"]
+        conflicts_with_all = &["zeros", "total"],
+        value_parser = to_lowercase_boxed_str
     )]
     pub pattern: Option<Box<str>>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ fn main() {
                         .unwrap_or(&pattern)
                         .to_owned()
                         .into_boxed_str();
-                    RewardVariant::Matching { pattern }
+                    RewardVariant::Matching {
+                        pattern: pattern,
+                    }
                 }
                 _ => unreachable!(),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,7 @@ fn main() {
                         .unwrap_or(&pattern)
                         .to_owned()
                         .into_boxed_str();
-                    RewardVariant::Matching {
-                        pattern: pattern,
-                    }
+                    RewardVariant::Matching { pattern: pattern }
                 }
                 _ => unreachable!(),
             };


### PR DESCRIPTION
Currently, uppercase hex letters used in the `--matching` setting are not able to find matches. This PR coerces all patterns to lowercase.

Closes #11 