### PR TITLE
Output addresses in EIP-55 checksum format

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,72 @@
+use alloy_primitives::hex;
+use sha3::{Digest, Keccak256};
+
+/// Convert an Ethereum address to EIP-55 checksum format
+/// 
+/// EIP-55 specifies that we hash the lowercase hex address (without 0x prefix)
+/// and use the hash to determine which characters should be uppercase.
+/// If the ith character is a letter (a-f) and the 4*ith bit of the hash is 1,
+/// then capitalize it.
+pub fn to_checksum_address(address: &[u8]) -> String {
+    // Convert address bytes to lowercase hex string (without 0x)
+    let hex_address = hex::encode(address);
+    
+    // Hash the lowercase hex address
+    let mut hasher = Keccak256::new();
+    hasher.update(hex_address.as_bytes());
+    let hash = hasher.finalize();
+    
+    // Build the checksum address
+    let mut checksum = String::with_capacity(42);
+    checksum.push_str("0x");
+    
+    for (i, ch) in hex_address.chars().enumerate() {
+        if ch.is_alphabetic() {
+            // Get the corresponding nibble from the hash
+            let hash_byte = hash[i / 2];
+            let nibble = if i % 2 == 0 {
+                (hash_byte >> 4) & 0xf
+            } else {
+                hash_byte & 0xf
+            };
+            
+            // If the corresponding bit is 1, uppercase the character
+            if nibble >= 8 {
+                checksum.push(ch.to_ascii_uppercase());
+            } else {
+                checksum.push(ch);
+            }
+        } else {
+            checksum.push(ch);
+        }
+    }
+    
+    checksum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn test_checksum_addresses() {
+        // Test vectors from EIP-55
+        let test_cases = vec![
+            ("52908400098527886e0f7030069857d2e4169ee7", "0x52908400098527886E0F7030069857D2E4169EE7"),
+            ("8617e340b3d01fa5f11f306f4090fd50e238070d", "0x8617E340B3D01FA5F11F306F4090FD50E238070D"),
+            ("de709f2102306220921060314715629080e2fb77", "0xde709f2102306220921060314715629080e2fb77"),
+            ("27b1fdb04752bbc536007a920d24acb045561c26", "0x27b1fdb04752bbc536007a920d24acb045561c26"),
+            ("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"),
+            ("fB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"),
+            ("dbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"),
+            ("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"),
+        ];
+        
+        for (input, expected) in test_cases {
+            let addr_bytes = hex::decode(input).unwrap();
+            let checksum = to_checksum_address(&addr_bytes);
+            assert_eq!(checksum, expected, "Failed for input: {}", input);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 use terminal_size::{terminal_size, Height};
 
 pub mod cli;
+pub mod checksum;
 
 const PROXY_CHILD_CODEHASH: [u8; 32] = [
     33, 195, 93, 190, 27, 52, 74, 36, 136, 207, 51, 33, 214, 206, 84, 47, 142, 159, 48, 85, 68,
@@ -503,7 +504,7 @@ pub fn gpu(config: Config) -> ocl::Result<()> {
             total += 1;
         }
 
-        let output = format!("0x{} => 0x{}", hex::encode(salt), hex::encode(address),);
+        let output = format!("0x{} => {}", hex::encode(salt), crate::checksum::to_checksum_address(&address));
 
         let show = format!("{output} ({leading} / {total})");
         match config.reward {


### PR DESCRIPTION
# Output addresses in EIP-55 checksum format

## Summary

This PR adds EIP-55 checksum formatting to all output addresses, improving compatibility with Ethereum tooling and making addresses more recognizable.

## Changes

- Added `src/checksum.rs` module implementing EIP-55 checksum address formatting
- Modified address output in `src/lib.rs` to use checksum format instead of lowercase hex

## Details

The implementation follows the EIP-55 specification:
1. Hash the lowercase hex address (without 0x prefix) using Keccak256
2. For each character in the address that is a letter (a-f), uppercase it if the corresponding bit in the hash is 1

## Example Output

Before:
```
0xe6ab51a5f6e3ff03ab49e6000000000000000000000000000000000000000000 => 0x003833d688046bc9b40aaf4629589850beb7d70e
```

After:
```
0xe6ab51a5f6e3ff03ab49e6000000000000000000000000000000000000000000 => 0x003833d688046bc9b40aAF4629589850bEb7d70e
```

## Testing

- Added unit tests for checksum implementation with official EIP-55 test vectors
- Manually tested mining functionality to ensure output is correctly formatted
- No changes to core mining logic or performance

## Backward Compatibility

This change only affects the display format of addresses in output. It does not affect:
- Pattern matching logic
- Mining performance
- Input parsing
- File format compatibility